### PR TITLE
fixed PlayerList restriction mixin

### DIFF
--- a/src/main/java/net/doulrion/toxicsteam/ToxicSteamPreLaunch.java
+++ b/src/main/java/net/doulrion/toxicsteam/ToxicSteamPreLaunch.java
@@ -1,0 +1,11 @@
+package net.doulrion.toxicsteam;
+
+import com.llamalad7.mixinextras.MixinExtrasBootstrap;
+import net.fabricmc.loader.api.entrypoint.PreLaunchEntrypoint;
+
+public class ToxicSteamPreLaunch implements PreLaunchEntrypoint {
+    @Override
+    public void onPreLaunch() {
+        MixinExtrasBootstrap.init();
+    }
+}

--- a/src/main/java/net/doulrion/toxicsteam/mixin/EntityMixin.java
+++ b/src/main/java/net/doulrion/toxicsteam/mixin/EntityMixin.java
@@ -17,7 +17,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 @Mixin(LivingEntity.class)
 public abstract class EntityMixin {
 
-    @Inject(at = @At(value = "TAIL"), method = "tick()V")
+    @Inject(method = "tick()V", at = @At(value = "TAIL"))
     private void tick(CallbackInfo cb) {
         LivingEntity entity = (LivingEntity) (Object) this;
 

--- a/src/main/java/net/doulrion/toxicsteam/mixin/InGameHudMixin.java
+++ b/src/main/java/net/doulrion/toxicsteam/mixin/InGameHudMixin.java
@@ -5,13 +5,14 @@ import net.doulrion.toxicsteam.init.ConfigInit;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.gui.DrawableHelper;
 import net.minecraft.client.gui.hud.InGameHud;
+import org.spongepowered.asm.mixin.Debug;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
 
-
+@Debug(export = true)
 @Mixin(InGameHud.class)
 public abstract class InGameHudMixin extends DrawableHelper {
     @Final
@@ -23,12 +24,12 @@ public abstract class InGameHudMixin extends DrawableHelper {
         at = @At(value = "INVOKE", target = "Lnet/minecraft/client/option/KeyBinding;isPressed()Z", ordinal = 0)
     )
     private boolean toxicSteam$restrictPlayerListKeyPressed(boolean original) {
-        ToxicSteam.devLogger("started mixin evaluation");
+        ToxicSteam.devLogger("started mixin evaluation | original: " + original);
         if (!ConfigInit.CONFIG.restrictPlayerList) return original;
-        if (!client.options.playerListKey.isPressed()) return false;
-        if (client.player == null) return false;
-        ToxicSteam.devLogger("custom evaluation is used | client in singleplayer: " + client.isInSingleplayer());
-        return !client.isInSingleplayer();
-    }
+        if (client.player == null || client.isInSingleplayer()) return original;
+        if (client.player.isCreative() || client.player.isSpectator()) return original;
+        if (client.options.playerListKey.isPressed()) return false;
 
+        else return original;
+    }
 }

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -19,6 +19,9 @@
 
   "environment": "*",
   "entrypoints": {
+    "preLaunch": [
+      "net.doulrion.toxicsteam.ToxicSteamPreLaunch"
+    ],
     "main": [
       "net.doulrion.toxicsteam.ToxicSteam"
     ],


### PR DESCRIPTION
- player list won't be opened in multiplayer when the player is in survival (also checks for config entry)